### PR TITLE
Fixed bug if no data is in stream, then opening marker is not pushed.…

### DIFF
--- a/src/jsonstream2.js
+++ b/src/jsonstream2.js
@@ -179,6 +179,8 @@ module.exports.stringify = function(open, sep, close, indent) {
 
     fn();
   }, function(fn) {
+    if(first) this.push(open);
+    first = false;
     this.push(close);
     fn();
   });
@@ -213,6 +215,8 @@ exports.stringifyObject = function (open, sep, close, indent) {
 
     fn();
   }, function(fn) {
+    if(first) this.push(open);
+    first = false;
     this.push(close);
     fn();
   });


### PR DESCRIPTION
… so we would get malformed array with just closing backet